### PR TITLE
Fix windows build

### DIFF
--- a/udp_windows.go
+++ b/udp_windows.go
@@ -4,13 +4,51 @@ package dns
 
 import "net"
 
+type SessionUDPFactory interface {
+	// SetSocketOptions sets the required UDP socket options on 'conn'.
+	// Must be called before 'conn' is passed to ReadRequest()
+	SetSocketOptions(conn *net.UDPConn) error
+
+	// InitPool initializes a pool of buffers to be used with SessionUDP.
+	// Must be called before calling ReadRequest()
+	InitPool(msgSize int)
+
+	// ReadRequest reads a single request from 'conn'.
+	// Returns the message buffer and the SessionUDP instance
+	// that is used to send the response.
+	ReadRequest(conn *net.UDPConn) ([]byte, SessionUDP, error)
+}
+
+type sessionUDPFactory struct{}
+
+var defaultSessionUDPFactory = &sessionUDPFactory{}
+
+// SetSocketOptions sets the required UDP socket options on 'conn'.
+func (s *sessionUDPFactory) SetSocketOptions(conn *net.UDPConn) error {
+	return nil
+}
+
+// InitPool initializes a pool of buffers to be used with SessionUDP.
+func (f *sessionUDPFactory) InitPool(msgSize int) {}
+
+// ReadRequest reads a single request from 'conn' and returns the request context
+func (f *sessionUDPFactory) ReadRequest(conn *net.UDPConn) ([]byte, SessionUDP, error) {
+	return nil, SessionUDP{}, nil
+}
+
 // SessionUDP holds the remote address
 type SessionUDP struct {
 	raddr *net.UDPAddr
 }
 
+func (s *SessionUDP) Discard() {}
+
 // RemoteAddr returns the remote network address.
 func (s *SessionUDP) RemoteAddr() net.Addr { return s.raddr }
+
+func (s *SessionUDP) LocalAddr() net.Addr { return &net.UDPAddr{} }
+
+func (s *SessionUDP) WriteResponse(b []byte) (int, error) { return 0, nil }
 
 // ReadFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
 // net.UDPAddr.


### PR DESCRIPTION
This package is a transitive dependency in cilium-cli, but currently it
fails to build on Windows after the Cilium-specific changes in commit
fd36f6f5d68a ("udp: Add SessionUDP, SessionUDPFactory interfaces.").

However, we want still to be able to build the pacakge for some these
platforms, see e.g. cilium/cilium-cli#231. Fix the build by providing
missing dummy implementations for SessionUDPFactory, sessionUDPFactory
and SessionUDP.

Fixes: fd36f6f5d68a ("udp: Add SessionUDP, SessionUDPFactory interfaces.")
Signed-off-by: Tobias Klauser <tobias@cilium.io>