### PR TITLE
shared client: Fix global timeout not being respected

### DIFF
--- a/shared_client.go
+++ b/shared_client.go
@@ -291,7 +291,7 @@ func (c *SharedClient) ExchangeSharedContext(ctx context.Context, m *Msg) (r *Ms
 
 	// This request keeps 'c.requests' open; sending a request may hang indefinitely if
 	// the handler happens to quit at the same time. Use ctx.Done to avoid this.
-	timeout := c.Client.writeTimeout()
+	timeout := c.getTimeoutForRequest(c.Client.writeTimeout())
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	respCh := make(chan sharedClientResponse)


### PR DESCRIPTION
This fixes a bug where the shared client did not respect `c.Client.Timeout`, resulting in DNS requests timing out too soon.

A per Go docs, `Client.Timeout` is supposed to also apply to the write timeout. This is implemented in the regular client by using `Client.getTimeoutForRequest` to determine the actual timeout. This commit adapts the shared client code to do the same.

Ref: https://github.com/cilium/cilium/pull/31999