### PR TITLE
shared_client: Try new id if already in use

### DIFF
--- a/shared_client.go
+++ b/shared_client.go
@@ -232,10 +232,20 @@ func handler(wg *sync.WaitGroup, client *Client, conn *Conn, requests chan reque
 			// Due to birthday paradox and the fact that ID is uint16
 			// it's likely to happen with small number (~200) of concurrent requests
 			// which would result in goroutine leak as we would never close req.ch
-			if _, ok := waitingResponses[req.msg.Id]; ok {
-				req.ch <- sharedClientResponse{nil, 0, fmt.Errorf("duplicate request id %d", req.msg.Id)}
-				close(req.ch)
-				continue
+			if _, duplicate := waitingResponses[req.msg.Id]; duplicate {
+				for n := 0; n < 5; n++ {
+					// Try a new ID
+					id := Id()
+					if _, duplicate = waitingResponses[id]; !duplicate {
+						req.msg.Id = id
+						break
+					}
+				}
+				if duplicate {
+					req.ch <- sharedClientResponse{nil, 0, fmt.Errorf("duplicate request id %d", req.msg.Id)}
+					close(req.ch)
+					continue
+				}
 			}
 
 			err := client.SendContext(req.ctx, req.msg, conn, start)


### PR DESCRIPTION
Only fail out if non-conflicting request id can not be found in couple of tries.

This works on the premise that the callers are fine with the request id being modified at this point. Current use sets a random id just prior to Exchange call, so this premise is satisfied.